### PR TITLE
While linking, when the output of a node is released over the canvas,…

### DIFF
--- a/Framework/NodeEditor.cs
+++ b/Framework/NodeEditor.cs
@@ -494,6 +494,7 @@ public static class NodeEditor
                             if (input.type == curEditorState.connectOutput.type)
                             {
                                 menu.AddItem (new GUIContent ("Add " + NodeTypes.nodes[node]), false, ContextCallback, new callbackObject(node.GetID, curNodeCanvas, curEditorState, null, curEditorState.connectOutput));
+                                break;
                             }
                         }
 					}


### PR DESCRIPTION
… open the create node menu, but only show nodes that are compatible with the current output node.

If a new node is created, automatically link its appropriate input node with the current output node.

Example: https://www.youtube.com/watch?v=Fh0Nw0-p7uc

Note: This will require you to hit escape in order to break existing connections, which might not be ideal. Any ideas for making this more intuitive?