### PR TITLE
Child nodes are now properly recalculated after parent deletion

### DIFF
--- a/Node_Editor/Framework/Node.cs
+++ b/Node_Editor/Framework/Node.cs
@@ -176,8 +176,8 @@ namespace NodeEditorFramework
 			for (int outCnt = 0; outCnt < Outputs.Count; outCnt++) 
 			{
 				NodeOutput output = Outputs [outCnt];
-				for (int conCnt = 0; conCnt < output.connections.Count; conCnt++) 
-					output.connections [conCnt].connection = null;
+				while (output.connections.Count != 0)
+					RemoveConnection(output.connections[0]);
 				DestroyImmediate (output, true);
 			}
 			for (int inCnt = 0; inCnt < Inputs.Count; inCnt++) 


### PR DESCRIPTION
If the parent was deleted with a right click -> delete node, the children wouldn't be notified that they required a recalculation.