### PR TITLE
Fix for DrawLine() outside of canvas rect

### DIFF
--- a/Node_Editor/Utilities/RTEditorGUI.cs
+++ b/Node_Editor/Utilities/RTEditorGUI.cs
@@ -315,7 +315,8 @@ namespace NodeEditorFramework.Utilities
 			if (Event.current.type != EventType.Repaint)
 				return;
 			
-			if(!NodeEditor.curEditorState.canvasRect.Contains(startPos) || !NodeEditor.curEditorState.canvasRect.Contains(endPos))
+			Rect canvasRect = NodeEditor.curEditorState.canvasRect;
+			if(!canvasRect.Contains(startPos + canvasRect.min) || !canvasRect.Contains(endPos + canvasRect.min))
 				return;
 			
 			if (width <= 1)

--- a/Node_Editor/Utilities/RTEditorGUI.cs
+++ b/Node_Editor/Utilities/RTEditorGUI.cs
@@ -315,6 +315,9 @@ namespace NodeEditorFramework.Utilities
 			if (Event.current.type != EventType.Repaint)
 				return;
 			
+			if(!NodeEditor.curEditorState.canvasRect.Contains(startPos) || !NodeEditor.curEditorState.canvasRect.Contains(endPos))
+				return;
+			
 			if (width <= 1)
 			{
 				GL.Begin (GL.LINES);


### PR DESCRIPTION
If you move the node canvas so the connections are outside of the rect, the lines will still be drawn (but not the nodes).

Example, using RuntimeNodeEditor (vertical split-screen - editor on top, game on bottom):
![](http://i.imgur.com/EzPrOOE.png)

![](http://i.imgur.com/aixZTqh.png)