### PR TITLE
Node positioning problem fix

### DIFF
--- a/Node_Editor/Framework/NodeEditor.cs
+++ b/Node_Editor/Framework/NodeEditor.cs
@@ -24,7 +24,7 @@ namespace NodeEditorFramework
 
 		private static bool unfocusControls;
 		public static Vector2 mousePos;
-        public static Vector2 contextMenuPos;
+		public static Vector2 contextMenuPos;
 
 		public static Action ClientRepaints;
 		public static void RepaintClients () 
@@ -419,8 +419,8 @@ namespace NodeEditorFramework
 					}
 					else if (e.button == 1) 
 					{ // Right click -> Editor Context Click
-                        contextMenuPos = e.mousePosition;   //Position of created GenericMenu
-                        if (curEditorState.connectOutput != null || curEditorState.makeTransition != null) 
+						contextMenuPos = e.mousePosition;   //Position of created GenericMenu
+						if (curEditorState.connectOutput != null || curEditorState.makeTransition != null) 
 						{
 							GenericMenu menu = new GenericMenu ();
 
@@ -616,7 +616,7 @@ namespace NodeEditorFramework
 			default:
 				Vector2 createPos = ScreenToGUIPos(contextMenuPos);
 
-                Node node = NodeTypes.getDefaultNode (callback.message);
+				Node node = NodeTypes.getDefaultNode (callback.message);
 				if (node == null)
 					break;
 

--- a/Node_Editor/Framework/NodeEditor.cs
+++ b/Node_Editor/Framework/NodeEditor.cs
@@ -24,6 +24,7 @@ namespace NodeEditorFramework
 
 		private static bool unfocusControls;
 		public static Vector2 mousePos;
+        public static Vector2 contextMenuPos;
 
 		public static Action ClientRepaints;
 		public static void RepaintClients () 
@@ -418,7 +419,8 @@ namespace NodeEditorFramework
 					}
 					else if (e.button == 1) 
 					{ // Right click -> Editor Context Click
-						if (curEditorState.connectOutput != null || curEditorState.makeTransition != null) 
+                        contextMenuPos = e.mousePosition;   //Position of created GenericMenu
+                        if (curEditorState.connectOutput != null || curEditorState.makeTransition != null) 
 						{
 							GenericMenu menu = new GenericMenu ();
 
@@ -612,9 +614,9 @@ namespace NodeEditorFramework
 				break;
 
 			default:
-				Vector2 createPos = ScreenToGUIPos (mousePos);
+				Vector2 createPos = ScreenToGUIPos(contextMenuPos);
 
-				Node node = NodeTypes.getDefaultNode (callback.message);
+                Node node = NodeTypes.getDefaultNode (callback.message);
 				if (node == null)
 					break;
 


### PR DESCRIPTION
During node creation there was a problem of positioning created node. It spawned node at the mouse position at the time of creation. 
Fixed that by spawning new node at context menu position.

Changes: Added variable Vector2 contextMenuPos that holds mouse position at the moment of creating context menu (only when clicked on the empty canvas).
Changed spawning position of new node to that position

PS Really sorry for bad English