### PR TITLE
Alternate comparison for node types when connecting

### DIFF
--- a/Node_Editor/Framework/Node.cs
+++ b/Node_Editor/Framework/Node.cs
@@ -518,7 +518,7 @@ namespace NodeEditorFramework
 				return false;
 			if (input.body == output.body || input.connection == output)
 				return false;
-			if (input.type != output.type)
+			if (input.typeData.Type != output.typeData.Type)
 				return false;
 
 			bool isRecursive = output.body.isChildOf (input.body);


### PR DESCRIPTION
Users might want to create similar input/outputs classes of the same type but with different colors/knob textures.

These classes should be compatible, but their respective nodes can't be connected because the current comparison uses the class type of each ITypeDeclaration. 
(p.e. FloatType vs FloatType2)

Changing this comparison to use __ITypeDeclaration.Type__ instead, would allow FloatType to connect to FloatType2, because both their __Type__ is __typeof(float)__.
