### PR TITLE
Added optional node property editor to side window of NodeEditorWindow

### DIFF
--- a/Editor/Node_Editor/NodeEditorWindow.cs
+++ b/Editor/Node_Editor/NodeEditorWindow.cs
@@ -197,7 +197,10 @@ namespace NodeEditorFramework
 
 			NodeEditorGUI.knobSize = EditorGUILayout.IntSlider (new GUIContent ("Handle Size", "The size of the Node Input/Output handles"), NodeEditorGUI.knobSize, 12, 20);
 			mainEditorState.zoom = EditorGUILayout.Slider (new GUIContent ("Zoom", "Use the Mousewheel. Seriously."), mainEditorState.zoom, 0.6f, 2);
-		}
+
+            if (mainEditorState.selectedNode != null)
+                mainEditorState.selectedNode.DrawNodePropertyEditor();
+        }
 
 		#endregion
 

--- a/Editor/Node_Editor/NodeEditorWindow.cs
+++ b/Editor/Node_Editor/NodeEditorWindow.cs
@@ -199,7 +199,8 @@ namespace NodeEditorFramework
 			mainEditorState.zoom = EditorGUILayout.Slider (new GUIContent ("Zoom", "Use the Mousewheel. Seriously."), mainEditorState.zoom, 0.6f, 2);
 
             if (mainEditorState.selectedNode != null)
-                mainEditorState.selectedNode.DrawNodePropertyEditor();
+                if (Event.current.type != EventType.Ignore)
+                    mainEditorState.selectedNode.DrawNodePropertyEditor();
         }
 
 		#endregion

--- a/Node_Editor/Framework/Node.cs
+++ b/Node_Editor/Framework/Node.cs
@@ -286,6 +286,12 @@ namespace NodeEditorFramework
 			}
 		}
 
+        /// <summary>
+        /// Used to display a custom node property editor in the side window of the NodeEditorWindow
+        /// Optionally override this to implement
+        /// </summary>
+        public virtual void DrawNodePropertyEditor() { }
+
 		#endregion
 		
 		#region Node Calculation Utility


### PR DESCRIPTION
A custom, yet optional, node property editor displays in the side window NodeEditorWindow when the node subclass overrides the DrawNodePropertyEditor method.  Just add IMGUI (immediate mode GUI) layout elements inside this method and they appear in the side window.

Example Usage:
```
public override void DrawNodePropertyEditor()
{
	name = GUILayout.TextField(name);    
}

```
Refer to Issue: https://github.com/Baste-RainGames/Node_Editor/issues/45#issuecomment-186201515