### PR TITLE
Canvas clipping for Bezier and Lines

### DIFF
--- a/Node_Editor/Utilities/RTEditorGUI.cs
+++ b/Node_Editor/Utilities/RTEditorGUI.cs
@@ -445,6 +445,7 @@ namespace NodeEditorFramework.Utilities
 
 					if (clippedP0)
 					{ // Just became visible, so enable GL again and draw the clipped line start point
+						GL.End();
 						GL.Begin (GL.TRIANGLE_STRIP);
 						DrawLineSegment (curPoint, perpendicular * width/2);
 					}
@@ -455,8 +456,11 @@ namespace NodeEditorFramework.Utilities
 					// Draw the actual point
 					DrawLineSegment (nextPoint, perpendicular * width/2);
 				}
-				else if (clippedP1) // Just became invisible, so disable GL
+				else if (clippedP1)
+				{ // Just became invisible, so disable GL
 					GL.End ();
+					GL.Begin (GL.TRIANGLE_STRIP);
+				}
 
 				// Update state variable
 				curPoint = nextPointOriginal;

--- a/Node_Editor/Utilities/RTEditorGUI.cs
+++ b/Node_Editor/Utilities/RTEditorGUI.cs
@@ -393,6 +393,8 @@ namespace NodeEditorFramework.Utilities
 			Vector2 curPoint = startPos;
 			Vector2 nextPoint = curPoint;
 
+			Vector2 curEnd = curPoint;
+
 			bool previousClipped = false, currentClipped = false;
 
 			for (int segCnt = 1; segCnt <= segmentCount; segCnt++) 
@@ -402,22 +404,44 @@ namespace NodeEditorFramework.Utilities
 
 				if (SegmentRectIntersection(clippingRect, ref curPoint, ref nextPoint, ref currentClipped))
 				{
-					DrawLineSegment (curPoint, new Vector2 (nextPoint.y-curPoint.y, curPoint.x-nextPoint.x).normalized * width/2);
-				}
+					curEnd = nextPoint;
 
-				if(previousClipped && currentClipped)
-				{
-					GL.End ();
-					GL.Begin (GL.TRIANGLE_STRIP);
-					nextPoint = nextPointOriginal;
+					if(currentClipped)
+					{
+						if(previousClipped)
+						{
+							GL.End ();
+							GL.Begin (GL.TRIANGLE_STRIP);
+							DrawLineSegment (curPoint, new Vector2 (nextPointOriginal.y-curPoint.y, curPoint.x-nextPointOriginal.x).normalized * width/2);
+							DrawLineSegment (nextPoint, new Vector2 (nextPoint.y-curPoint.y, curPoint.x-nextPoint.x).normalized * width/4);
+							nextPoint = nextPointOriginal;
+						}
+						else
+						{
+							DrawLineSegment (curPoint, new Vector2 (nextPoint.y-curPoint.y, curPoint.x-nextPoint.x).normalized * width/2);
+							DrawLineSegment (nextPoint, new Vector2 (nextPoint.y-curPoint.y, curPoint.x-nextPoint.x).normalized * width/4);
+							nextPoint = nextPointOriginal;
+							GL.End ();
+							GL.Begin (GL.TRIANGLE_STRIP);
+						}
+					}
+					else
+					{
+						if(previousClipped)
+						{
+							GL.End ();
+							GL.Begin (GL.TRIANGLE_STRIP);
+						}
+
+						DrawLineSegment (curPoint, new Vector2 (nextPoint.y-curPoint.y, curPoint.x-nextPoint.x).normalized * width/2);
+					}
 				}
 
 				curPoint = nextPoint;
 				previousClipped = currentClipped;
 			}
 
-			if (SegmentRectIntersection(clippingRect, ref curPoint, ref nextPoint, ref currentClipped))
-				DrawLineSegment (curPoint, new Vector2 (endTan.y, -endTan.x).normalized * width/2);
+			DrawLineSegment(curEnd, new Vector2(endTan.y, -endTan.x).normalized * width / 2);
 
 			GL.End ();
 			GL.Color (Color.white);

--- a/Node_Editor/Utilities/RTEditorGUI.cs
+++ b/Node_Editor/Utilities/RTEditorGUI.cs
@@ -382,8 +382,9 @@ namespace NodeEditorFramework.Utilities
 			GL.Begin (GL.TRIANGLE_STRIP);
 			GL.Color (Color.white);
 
-			Rect clippingRect = NodeEditor.curEditorState.canvasRect;
-			clippingRect = GUIScaleUtility.ScaleRect(clippingRect, Vector2.zero, GUIScaleUtility.getCurrentScale);
+			Rect clippingRect = GUIScaleUtility.getTopRect;
+			clippingRect.x = 0;
+			clippingRect.y = 0;
 
 			// Calculate optimal segment count
 			int segmentCount = CalculateBezierSegmentCount (startPos, endPos, startTan, endTan);
@@ -471,8 +472,10 @@ namespace NodeEditorFramework.Utilities
 			GL.Color (Color.white);
 			Vector2 perpWidthOffset = new Vector2 ((endPos-startPos).y, -(endPos-startPos).x).normalized * width / 2;
 
-			Rect clippingRect = NodeEditor.curEditorState.canvasRect;
-			clippingRect = GUIScaleUtility.ScaleRect(clippingRect, Vector2.zero, GUIScaleUtility.getCurrentScale);
+			Rect clippingRect = GUIScaleUtility.getTopRect;
+			clippingRect.x = 0;
+			clippingRect.y = 0;
+
 			if (SegmentRectIntersection(clippingRect, ref startPos, ref endPos))
 			{
 				DrawLineSegment (startPos, perpWidthOffset);


### PR DESCRIPTION
Fixes #44.

There is a minor issue with clipping __some__ Beziers curves when they are really long, where some segments disappear instead of being clipped. It's only really noticeable with max zoom.

I think this might be related with the orientation of a line (order of the vertices), but I couldn't pinpoint exactly why or how to solve it.