### PR TITLE
Fixed null pointer on node.

### DIFF
--- a/Node_Editor/Framework/NodeEditor.cs
+++ b/Node_Editor/Framework/NodeEditor.cs
@@ -220,14 +220,18 @@ namespace NodeEditorFramework
 
 			// Draw the transitions and connections. Has to be drawn before nodes as transitions originate from node centers
 			foreach (Node node in curNodeCanvas.nodes)
-				node.DrawConnections ();
+				if (node != null)
+					node.DrawConnections ();
 
 			// Draw the nodes
 			foreach (Node node in curNodeCanvas.nodes)
 			{
-				node.DrawNode ();
-				if (Event.current.type == EventType.Repaint)
-					node.DrawKnobs ();
+				if (node != null)
+				{
+					node.DrawNode ();
+					if (Event.current.type == EventType.Repaint)
+						node.DrawKnobs ();
+				}
 			}
 
 			// ---- END SCALE ----


### PR DESCRIPTION
For some reason I get a **NullReferenceException** if I start Unity with the Node_Editor. A node in curNodeCanvas.nodes seems to be null. This leads to a frozen node window. 

Unity 5.3.4f1 Personal (Mac)

```
NullReferenceException:` Object reference not set to an instance of an object
NodeEditorFramework.NodeEditor.DrawSubCanvas (NodeEditorFramework.NodeCanvas nodeCanvas, NodeEditorFramework.NodeEditorState editorState) (at Assets/Node_Editor/Framework/NodeEditor.cs:223)
NodeEditorFramework.NodeEditor.DrawCanvas (NodeEditorFramework.NodeCanvas nodeCanvas, NodeEditorFramework.NodeEditorState editorState) (at Assets/Node_Editor/Framework/NodeEditor.cs:131)
NodeEditorFramework.NodeEditorWindow.OnGUI () (at Assets/Editor/Node_Editor/NodeEditorWindow.cs:127)
System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MonoMethod.cs:222)
```

To fix this issue I checked for null on the nodes.