### PR TITLE
Add subclass acceptance for Connections

### DIFF
--- a/Node_Editor/Framework/NodeInput.cs
+++ b/Node_Editor/Framework/NodeInput.cs
@@ -107,7 +107,7 @@ namespace NodeEditorFramework
 		/// </summary>
 		public bool CanApplyConnection (NodeOutput output)
 		{
-			if (output == null || body == output.body || connection == output || typeData.Type != output.typeData.Type)
+			if (output == null || body == output.body || connection == output || (typeData.Type != output.typeData.Type && !output.typeData.Type.IsSubclassOf(typeData.Type)))
 				return false;
 
 			if (output.body.isChildOf (body)) 

--- a/Node_Editor/Framework/NodeOutput.cs
+++ b/Node_Editor/Framework/NodeOutput.cs
@@ -90,7 +90,7 @@ namespace NodeEditorFramework
 		public T GetValue<T> ()
 		{
 			CheckType ();
-			if (typeData.Type == typeof(T))
+			if (typeData.Type == typeof(T) || typeData.Type.IsSubclassOf(typeof(T)))
 				return (T)(value?? (value = GetDefault<T> ()));
 			Debug.LogError ("Trying to GetValue<" + typeof(T).FullName + "> for Output Type: " + typeData.Type.FullName);
 			return GetDefault<T> ();


### PR DESCRIPTION
Allows connection of two Nodes if the Type of the output Connection is a subclass of the Type of the input Connection.

I needed this feature to allow Connections of different Types that inherit from the same abstract class. 