### PR TITLE
Connections Curves Improvement

### DIFF
--- a/Editor/Node_Editor/NodeEditorWindow.cs
+++ b/Editor/Node_Editor/NodeEditorWindow.cs
@@ -258,6 +258,10 @@ namespace NodeEditorFramework.Standard
 			NodeEditorGUI.knobSize = EditorGUILayout.IntSlider (new GUIContent ("Handle Size", "The size of the Node Input/Output handles"), NodeEditorGUI.knobSize, 12, 20);
 			canvasCache.editorState.zoom = EditorGUILayout.Slider (new GUIContent ("Zoom", "Use the Mousewheel. Seriously."), canvasCache.editorState.zoom, 0.6f, 4);
 
+//			NodeEditorGUI.curveBaseDirection = EditorGUILayout.FloatField ("Curve Base Dir", NodeEditorGUI.curveBaseDirection);
+//			NodeEditorGUI.curveBaseStart = EditorGUILayout.FloatField ("Curve Base Start", NodeEditorGUI.curveBaseStart);
+//			NodeEditorGUI.curveDirectionScale = EditorGUILayout.FloatField ("Curve Dir Scale", NodeEditorGUI.curveDirectionScale);
+
 			if (canvasCache.editorState.selectedNode != null && Event.current.type != EventType.Ignore)
 				canvasCache.editorState.selectedNode.DrawNodePropertyEditor();
 		}

--- a/Node_Editor/Framework/Node.cs
+++ b/Node_Editor/Framework/Node.cs
@@ -283,10 +283,13 @@ namespace NodeEditorFramework
 				for (int conCnt = 0; conCnt < output.connections.Count; conCnt++) 
 				{
 					NodeInput input = output.connections [conCnt];
+					//TODO Move 100f to somewhere to follow D.R.Y. Principles. (also used in NodeEditor.cs' "Draw the currently drawn connection" if statement, inside DrawSubCanvas())
+					Vector2 offset = (input.GetGUIKnob ().center - startPos) / 100f;
+					offset = new Vector2 (Mathf.Abs (offset.x), Mathf.Abs (offset.y));
 					NodeEditorGUI.DrawConnection (startPos,
-													startDir,
+													Vector2.Scale(startDir, offset),
 													input.GetGUIKnob ().center,
-													input.GetDirection (),
+													Vector2.Scale(input.GetDirection(), offset),
 													output.typeData.Color);
 				}
 			}

--- a/Node_Editor/Framework/Node.cs
+++ b/Node_Editor/Framework/Node.cs
@@ -283,14 +283,10 @@ namespace NodeEditorFramework
 				for (int conCnt = 0; conCnt < output.connections.Count; conCnt++) 
 				{
 					NodeInput input = output.connections [conCnt];
-					//TODO Move 100f to somewhere to follow D.R.Y. Principles. (also used in NodeEditor.cs' "Draw the currently drawn connection" if statement, inside DrawSubCanvas())
-					Vector2 offset = (input.GetGUIKnob ().center - startPos) / 100f;
-					offset = new Vector2 (Mathf.Abs (offset.x), Mathf.Abs (offset.y));
-					NodeEditorGUI.DrawConnection (startPos,
-													Vector2.Scale(startDir, offset),
-													input.GetGUIKnob ().center,
-													Vector2.Scale(input.GetDirection(), offset),
-													output.typeData.Color);
+					Vector2 endPos = input.GetGUIKnob ().center;
+					Vector2 endDir = input.GetDirection();
+					NodeEditorGUI.OptimiseBezierDirections (startPos, ref startDir, endPos, ref endDir);
+					NodeEditorGUI.DrawConnection (startPos, startDir, endPos, endDir, output.typeData.Color);
 				}
 			}
 		}

--- a/Node_Editor/Framework/NodeEditor.cs
+++ b/Node_Editor/Framework/NodeEditor.cs
@@ -216,9 +216,15 @@ namespace NodeEditorFramework
 				Vector2 startPos = output.GetGUIKnob ().center;
 				Vector2 startDir = output.GetDirection ();
 				Vector2 endPos = Event.current.mousePosition;
+				Vector2 offset = endPos - startPos;
 				// There is no specific direction of the end knob so we pick the best according to the relative position
-				Vector2 endDir = NodeEditorGUI.GetSecondConnectionVector (startPos, endPos, startDir);
-				NodeEditorGUI.DrawConnection (startPos, startDir, endPos, endDir, output.typeData.Color);
+				// Disabled because it causes the connection we are drawing to snap to a different curve when you pass it parallel to the
+				// source knob, which is slightly unpleasent. Replaced with a negative startdir.
+				//Vector2 endDir = NodeEditorGUI.GetSecondConnectionVector (startPos, endPos, startDir);
+
+				//TODO Move 100f to somewhere to follow D.R.Y. Principles. Also used in Node.cs' DrawConnections()
+				startDir = new Vector2(startDir.x*Mathf.Abs (offset.x),startDir.y*Mathf.Abs (offset.y)) / 100f;
+				NodeEditorGUI.DrawConnection (startPos, startDir, endPos, -startDir, output.typeData.Color);
 				RepaintClients ();
 			}
 

--- a/Node_Editor/Framework/NodeEditor.cs
+++ b/Node_Editor/Framework/NodeEditor.cs
@@ -216,15 +216,10 @@ namespace NodeEditorFramework
 				Vector2 startPos = output.GetGUIKnob ().center;
 				Vector2 startDir = output.GetDirection ();
 				Vector2 endPos = Event.current.mousePosition;
-				Vector2 offset = endPos - startPos;
-				// There is no specific direction of the end knob so we pick the best according to the relative position
-				// Disabled because it causes the connection we are drawing to snap to a different curve when you pass it parallel to the
-				// source knob, which is slightly unpleasent. Replaced with a negative startdir.
-				//Vector2 endDir = NodeEditorGUI.GetSecondConnectionVector (startPos, endPos, startDir);
+				Vector2 endDir = -startDir; // NodeEditorGUI.GetSecondConnectionVector (startPos, endPos, startDir); <- causes unpleasant jumping when switching polarity
 
-				//TODO Move 100f to somewhere to follow D.R.Y. Principles. Also used in Node.cs' DrawConnections()
-				startDir = new Vector2(startDir.x*Mathf.Abs (offset.x),startDir.y*Mathf.Abs (offset.y)) / 100f;
-				NodeEditorGUI.DrawConnection (startPos, startDir, endPos, -startDir, output.typeData.Color);
+				NodeEditorGUI.OptimiseBezierDirections (startPos, ref startDir, endPos, ref endDir);
+				NodeEditorGUI.DrawConnection (startPos, startDir, endPos, endDir, output.typeData.Color);
 				RepaintClients ();
 			}
 

--- a/Node_Editor/Framework/NodeEditorGUI.cs
+++ b/Node_Editor/Framework/NodeEditorGUI.cs
@@ -102,6 +102,9 @@ namespace NodeEditorFramework
 
 		#region Connection Drawing
 
+		// Curve parameters
+		public static float curveBaseDirection = 1.5f, curveBaseStart = 2f, curveDirectionScale = 0.004f;
+
 		/// <summary>
 		/// Draws a node connection from start to end, horizontally
 		/// </summary>
@@ -134,6 +137,21 @@ namespace NodeEditorFramework
 			}
 			else if (drawMethod == ConnectionDrawMethod.StraightLine)
 				RTEditorGUI.DrawLine (startPos, endPos, col * Color.gray, null, 3);
+		}
+
+		/// <summary>
+		/// Optimises the bezier directions scale so that the bezier looks good in the specified position relation.
+		/// Only the magnitude of the directions are changed, not their direction!
+		/// </summary>
+		public static void OptimiseBezierDirections (Vector2 startPos, ref Vector2 startDir, Vector2 endPos, ref Vector2 endDir) 
+		{
+			Vector2 offset = (endPos - startPos) * curveDirectionScale;
+			float baseDir = Mathf.Min (offset.magnitude/curveBaseStart, 1) * curveBaseDirection;
+			Vector2 scale = new Vector2 (Mathf.Abs (offset.x) + baseDir, Mathf.Abs (offset.y) + baseDir);
+			// offset.x and offset.y linearly increase at scale of curveDirectionScale
+			// For 0 < offset.magnitude < curveBaseStart, baseDir linearly increases from 0 to curveBaseDirection. For offset.magnitude > curveBaseStart, baseDir = curveBaseDirection
+			startDir = Vector2.Scale(startDir.normalized, scale);
+			endDir = Vector2.Scale(endDir.normalized, scale);
 		}
 
 		/// <summary>


### PR DESCRIPTION
I felt the need to do something small to get acquainted with this codebase, so I made the curves prettier.
They used to snap to a different angle when you crossed the space above or below a knob with the mouse while drawing a new connection from it.
Comparison of curves:  (Blue is improved, Red is previous. Top right connection is most important change)
![screenshot 2016-12-24 11 48 47](https://cloud.githubusercontent.com/assets/4543739/21469164/a8ca61a0-c9f1-11e6-9f4e-b719b16e7318.png)

TODO:
Move the 100f in Node.cs and NodeEditor.cs to a single location somewhere.
Either fully remove NodeEditorGUI.GetSecondConnectionVector or re-enable it.
TLDR:
I made the connections act a little more like blenders, and have stopped using the NodeEditorGUI.GetSecondConnectionVector function