### PR TITLE
Add optional, automatic resizing to nodes

### DIFF
--- a/Node_Editor/Nodes/Example/ExampleNode.cs
+++ b/Node_Editor/Nodes/Example/ExampleNode.cs
@@ -7,14 +7,17 @@ namespace NodeEditorFramework.Standard
 	[Node (false, "Example/Example Node")]
 	public class ExampleNode : Node 
 	{
+		public override Vector2 MinSize { get { return new Vector2(150, 10); } }
+		public override bool Resizable { get { return true; } }
+
 		public const string ID = "exampleNode";
 		public override string GetID { get { return ID; } }
 		
 		public override Node Create (Vector2 pos) 
 		{
 			ExampleNode node = CreateInstance<ExampleNode> ();
-			
-			node.rect = new Rect (pos.x, pos.y, 150, 60);
+
+			node.rect.position = pos;
 			node.name = "Example Node";
 			
 			node.CreateInput ("Value", "Float");

--- a/Node_Editor/Nodes/Example/ExampleNode.cs
+++ b/Node_Editor/Nodes/Example/ExampleNode.cs
@@ -7,17 +7,14 @@ namespace NodeEditorFramework.Standard
 	[Node (false, "Example/Example Node")]
 	public class ExampleNode : Node 
 	{
-		public override Vector2 MinSize { get { return new Vector2(150, 10); } }
-		public override bool Resizable { get { return true; } }
-
 		public const string ID = "exampleNode";
 		public override string GetID { get { return ID; } }
 		
 		public override Node Create (Vector2 pos) 
 		{
 			ExampleNode node = CreateInstance<ExampleNode> ();
-
-			node.rect.position = pos;
+			
+			node.rect = new Rect (pos.x, pos.y, 150, 60);
 			node.name = "Example Node";
 			
 			node.CreateInput ("Value", "Float");

--- a/Node_Editor/Nodes/Example/ResizingNode.cs
+++ b/Node_Editor/Nodes/Example/ResizingNode.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace NodeEditorFramework.Standard
+{
+    [Node(false, "Example/Resizing Node")]
+    public class ResizingNode : Node
+    {
+        public override Vector2 MinSize { get { return new Vector2(200, 10); } }
+        public override bool Resizable { get { return true; } }
+
+        public override string GetID { get { return "resizingNode"; } }
+
+        public override Node Create(Vector2 pos)
+        {
+            ResizingNode node = CreateInstance<ResizingNode>();
+
+            node.rect.position = pos;
+            node.name = "Resizing Node";
+
+            return node;
+        }
+
+        private List<string> labels = new List<string>();
+        private string newLabel = "";
+        protected internal override void NodeGUI()
+        {
+            GUILayout.Label("This node resizes to fit all inputs!");
+
+            GUILayout.BeginVertical();
+
+            GUILayout.BeginHorizontal();
+
+            newLabel = GUILayout.TextField(newLabel);
+            if (GUILayout.Button("Add", GUILayout.ExpandWidth(false)))
+                labels.Add(newLabel);
+
+            GUILayout.EndHorizontal();
+
+            string labelToRemove = null;
+            foreach(var text in labels)
+            {
+                GUILayout.BeginHorizontal();
+
+                GUILayout.Label(text);
+
+                if(GUILayout.Button("x", GUILayout.ExpandWidth(false)))
+                    labelToRemove = text;
+
+                GUILayout.EndHorizontal();
+            }
+
+            if (!string.IsNullOrEmpty(labelToRemove))
+            {
+                labels.Remove(labelToRemove);
+                labelToRemove = null;
+            }
+
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/Node_Editor/Nodes/Example/ResizingNode.cs.meta
+++ b/Node_Editor/Nodes/Example/ResizingNode.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b10f04280dcb14a40bbcd4ae5599e365
+timeCreated: 1485641363
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
As per issue #39 this gives nodes the ability to resize according to the `GUILayout` content inside of them. I made this optional and defaulted it to being off, since it'll probably break the size of old nodes.

To use, override `Vector2 MinSize` and `bool Resizable` and only set the `rect.position`:
```cs
        public override Vector2 MinSize { get { return new Vector2(200, 10); } }
        public override bool Resizable { get { return true; } }

        public override string GetID { get { return "resizingNode"; } }

        public override Node Create(Vector2 pos)
        {
            ResizingNode node = CreateInstance<ResizingNode>();

            node.rect.position = pos;
            node.name = "Resizing Node";

            return node;
        }
```

![](https://transientbug.ninja/scrn/screencast_2017-01-28_15-46-31.gif)