### PR TITLE
Fix obsolete warning in 2017.2 and above

### DIFF
--- a/Node_Editor/Utilities/EditorLoadingControl.cs
+++ b/Node_Editor/Utilities/EditorLoadingControl.cs
@@ -41,8 +41,13 @@ namespace NodeEditorFramework.Utilities
 #endif
 			EditorApplication.update -= Update;
 			EditorApplication.update += Update;
+#if UNITY_2018_1_OR_NEWER
+			EditorApplication.hierarchyChanged -= OnHierarchyChange;
+			EditorApplication.hierarchyChanged += OnHierarchyChange;
+#else
 			EditorApplication.hierarchyWindowChanged -= OnHierarchyChange;
 			EditorApplication.hierarchyWindowChanged += OnHierarchyChange;
+#endif
 		}
 
 		private static void OnHierarchyChange () 

--- a/Node_Editor/Utilities/EditorLoadingControl.cs
+++ b/Node_Editor/Utilities/EditorLoadingControl.cs
@@ -32,8 +32,13 @@ namespace NodeEditorFramework.Utilities
 
 		static EditorLoadingControl () 
 		{
+#if UNITY_2017_2_OR_NEWER
+			EditorApplication.playModeStateChanged -= PlayModeStateChanged;
+			EditorApplication.playModeStateChanged += PlayModeStateChanged;
+#else
 			EditorApplication.playmodeStateChanged -= PlaymodeStateChanged;
 			EditorApplication.playmodeStateChanged += PlaymodeStateChanged;
+#endif
 			EditorApplication.update -= Update;
 			EditorApplication.update += Update;
 			EditorApplication.hierarchyWindowChanged -= OnHierarchyChange;
@@ -65,6 +70,11 @@ namespace NodeEditorFramework.Utilities
 					lateEnteredPlayMode.Invoke ();
 			}
 			serializationTest = true;
+		}
+
+		private static void PlayModeStateChanged(PlayModeStateChange stateChange)
+		{
+			PlaymodeStateChanged();
 		}
 
 		private static void PlaymodeStateChanged () 


### PR DESCRIPTION
Change PlaymodeStateChanged to [PlayModeStateChange](https://github.com/UnityCommunity/UnityReleaseNotes/search?q=playModeStateChanged) for Unity 2017.2 or higher.

(I've added #if gate for that).

Feel free to discuss if something feels doesn't right.

