### PR TITLE
OnRemoveConnection

### DIFF
--- a/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
+++ b/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
@@ -260,7 +260,8 @@ namespace NodeEditorFramework
 
 			if (!silent)
 			{
-				port.body.OnRemoveConnection(this, port);
+				port.body.OnRemoveConnection(port, this);
+				this.body.OnRemoveConnection(this, port);
 				NodeEditorCallbacks.IssueOnRemoveConnection (this, port);
 			}
 			

--- a/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
+++ b/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 using NodeEditorFramework.Utilities;
 
-namespace NodeEditorFramework 
+namespace NodeEditorFramework
 {
 	public enum NodeSide { Left = 4, Top = 3, Right = 2, Bottom = 1 }
 	public enum Direction { None, In, Out }
@@ -34,7 +34,7 @@ namespace NodeEditorFramework
 		protected List<ConnectionPort> _connections = new List<ConnectionPort> ();
 		public List<ConnectionPort> connections { get { return _connections; } }
 
-		public void Init (Node nodeBody, string knobName) 
+		public void Init (Node nodeBody, string knobName)
 		{
 			body = nodeBody;
 			name = knobName;
@@ -80,7 +80,7 @@ namespace NodeEditorFramework
 		/// </summary>
 		protected void CheckConnectionStyle ()
 		{
-			if (_connectionStyle == null || !_connectionStyle.isValid ()) 
+			if (_connectionStyle == null || !_connectionStyle.isValid ())
 			{
 				_connectionStyle = ConnectionPortStyles.GetPortStyle (styleID, styleBaseClass);
 				if (_connectionStyle == null || !_connectionStyle.isValid())
@@ -93,7 +93,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Draws the connection lines from this port to all it's connections
 		/// </summary>
-		public virtual void DrawConnections () 
+		public virtual void DrawConnections ()
 		{
 			if (Event.current.type != EventType.Repaint)
 				return;
@@ -108,7 +108,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Draws a connection line from the current knob to the specified position
 		/// </summary>
-		public virtual void DrawConnection (Vector2 endPos) 
+		public virtual void DrawConnection (Vector2 endPos)
 		{
 			if (Event.current.type != EventType.Repaint)
 				return;
@@ -122,7 +122,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Returns whether this port is connected to any other port
 		/// </summary>
-		public bool connected () 
+		public bool connected ()
 		{
 			return connections.Count > 0;
 		}
@@ -130,7 +130,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Returns the connection with the specified index or null if not existant
 		/// </summary>
-		public ConnectionPort connection (int index) 
+		public ConnectionPort connection (int index)
 		{
 			if (connections.Count <= index)
 				throw new IndexOutOfRangeException ("connections[" + index + "] of '" + name + "'");
@@ -142,7 +142,7 @@ namespace NodeEditorFramework
 		/// </summary>
 		public bool TryApplyConnection (ConnectionPort port, bool silent = false)
 		{
-			if (CanApplyConnection (port)) 
+			if (CanApplyConnection (port))
 			{ // This port and the specified port can be connected
 				ApplyConnection (port, silent);
 				return true;
@@ -165,7 +165,7 @@ namespace NodeEditorFramework
 				return false; // Cannot connect inputs with anything other than outputs
 			if (direction == Direction.Out && port.direction != Direction.In)
 				return false; // Cannot connect outputs with anything other than inputs
-			
+
 			if (!body.canvas.allowRecursion)
 			{ // Assure no loop would be created
 				bool loop;
@@ -182,12 +182,12 @@ namespace NodeEditorFramework
 		}
 
 		/// <summary>
-		/// Applies a connection between between this port and the specified port. 
+		/// Applies a connection between between this port and the specified port.
 		/// 'CanApplyConnection' has to be checked before to avoid interferences!
 		/// </summary>
 		public void ApplyConnection (ConnectionPort port, bool silent = false)
 		{
-			if (port == null) 
+			if (port == null)
 				return;
 
 			if (maxConnectionCount == ConnectionCount.Single && connections.Count > 0)
@@ -248,8 +248,6 @@ namespace NodeEditorFramework
 					() => NodeEditorUndoActions.DeleteConnection(port1, port2),
 					() => NodeEditorUndoActions.CreateConnection(port1, port2),
 					"Delete Connection");
-					
-				port.body.OnRemoveConnection(this, port);
 			}
 #endif
 
@@ -260,7 +258,12 @@ namespace NodeEditorFramework
 				return;
 			}
 
-			if (!silent) NodeEditorCallbacks.IssueOnRemoveConnection (this, port);
+			if (!silent)
+			{
+				port.body.OnRemoveConnection(this, port);
+				NodeEditorCallbacks.IssueOnRemoveConnection (this, port);
+			}
+
 			port.connections.Remove (this);
 			connections.Remove (port);
 
@@ -305,7 +308,7 @@ namespace NodeEditorFramework
 			Setup (name, direction, styleID, maxCount);
 		}
 
-		private void Setup (string name, Direction direction, string styleID, ConnectionCount maxCount) 
+		private void Setup (string name, Direction direction, string styleID, ConnectionCount maxCount)
 		{
 			Name = name;
 			Direction = direction;
@@ -313,7 +316,7 @@ namespace NodeEditorFramework
 			MaxConnectionCount = maxCount;
 		}
 
-		public bool MatchFieldType (Type fieldType) 
+		public bool MatchFieldType (Type fieldType)
 		{
 			return fieldType.IsAssignableFrom (ConnectionType);
 		}
@@ -331,7 +334,7 @@ namespace NodeEditorFramework
 			return true;
 		}
 
-		public virtual ConnectionPort CreateNew (Node body) 
+		public virtual ConnectionPort CreateNew (Node body)
 		{
 			ConnectionPort port = ScriptableObject.CreateInstance<ConnectionPort> ();
 			port.Init (body, Name);
@@ -341,7 +344,7 @@ namespace NodeEditorFramework
 			return port;
 		}
 
-		public virtual void UpdateProperties (ConnectionPort port) 
+		public virtual void UpdateProperties (ConnectionPort port)
 		{
 			port.name = Name;
 			port.direction = Direction;
@@ -361,7 +364,7 @@ namespace NodeEditorFramework
 
 		public ConnectionPortStyle () {}
 
-		public ConnectionPortStyle (string name) 
+		public ConnectionPortStyle (string name)
 		{
 			identifier = name;
 			GenerateColor();
@@ -372,7 +375,7 @@ namespace NodeEditorFramework
 			color = NodeEditorGUI.RandomColorHSV(Identifier.GetHashCode(), 0, 1, 0.6f, 0.8f, 0.8f, 1.4f);
 		}
 
-		public virtual bool isValid () 
+		public virtual bool isValid ()
 		{
 			return true;
 		}

--- a/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
+++ b/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
@@ -263,6 +263,7 @@ namespace NodeEditorFramework
 				port.body.OnRemoveConnection(this, port);
 				NodeEditorCallbacks.IssueOnRemoveConnection (this, port);
 			}
+			
 			port.connections.Remove (this);
 			connections.Remove (port);
 

--- a/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
+++ b/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
@@ -248,6 +248,8 @@ namespace NodeEditorFramework
 					() => NodeEditorUndoActions.DeleteConnection(port1, port2),
 					() => NodeEditorUndoActions.CreateConnection(port1, port2),
 					"Delete Connection");
+					
+				port.body.OnRemoveConnection(this, port);
 			}
 #endif
 

--- a/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
+++ b/Node_Editor_Framework/Runtime/Framework/Core/ConnectionPort.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 using NodeEditorFramework.Utilities;
 
-namespace NodeEditorFramework
+namespace NodeEditorFramework 
 {
 	public enum NodeSide { Left = 4, Top = 3, Right = 2, Bottom = 1 }
 	public enum Direction { None, In, Out }
@@ -34,7 +34,7 @@ namespace NodeEditorFramework
 		protected List<ConnectionPort> _connections = new List<ConnectionPort> ();
 		public List<ConnectionPort> connections { get { return _connections; } }
 
-		public void Init (Node nodeBody, string knobName)
+		public void Init (Node nodeBody, string knobName) 
 		{
 			body = nodeBody;
 			name = knobName;
@@ -80,7 +80,7 @@ namespace NodeEditorFramework
 		/// </summary>
 		protected void CheckConnectionStyle ()
 		{
-			if (_connectionStyle == null || !_connectionStyle.isValid ())
+			if (_connectionStyle == null || !_connectionStyle.isValid ()) 
 			{
 				_connectionStyle = ConnectionPortStyles.GetPortStyle (styleID, styleBaseClass);
 				if (_connectionStyle == null || !_connectionStyle.isValid())
@@ -93,7 +93,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Draws the connection lines from this port to all it's connections
 		/// </summary>
-		public virtual void DrawConnections ()
+		public virtual void DrawConnections () 
 		{
 			if (Event.current.type != EventType.Repaint)
 				return;
@@ -108,7 +108,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Draws a connection line from the current knob to the specified position
 		/// </summary>
-		public virtual void DrawConnection (Vector2 endPos)
+		public virtual void DrawConnection (Vector2 endPos) 
 		{
 			if (Event.current.type != EventType.Repaint)
 				return;
@@ -122,7 +122,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Returns whether this port is connected to any other port
 		/// </summary>
-		public bool connected ()
+		public bool connected () 
 		{
 			return connections.Count > 0;
 		}
@@ -130,7 +130,7 @@ namespace NodeEditorFramework
 		/// <summary>
 		/// Returns the connection with the specified index or null if not existant
 		/// </summary>
-		public ConnectionPort connection (int index)
+		public ConnectionPort connection (int index) 
 		{
 			if (connections.Count <= index)
 				throw new IndexOutOfRangeException ("connections[" + index + "] of '" + name + "'");
@@ -142,7 +142,7 @@ namespace NodeEditorFramework
 		/// </summary>
 		public bool TryApplyConnection (ConnectionPort port, bool silent = false)
 		{
-			if (CanApplyConnection (port))
+			if (CanApplyConnection (port)) 
 			{ // This port and the specified port can be connected
 				ApplyConnection (port, silent);
 				return true;
@@ -165,7 +165,7 @@ namespace NodeEditorFramework
 				return false; // Cannot connect inputs with anything other than outputs
 			if (direction == Direction.Out && port.direction != Direction.In)
 				return false; // Cannot connect outputs with anything other than inputs
-
+			
 			if (!body.canvas.allowRecursion)
 			{ // Assure no loop would be created
 				bool loop;
@@ -182,12 +182,12 @@ namespace NodeEditorFramework
 		}
 
 		/// <summary>
-		/// Applies a connection between between this port and the specified port.
+		/// Applies a connection between between this port and the specified port. 
 		/// 'CanApplyConnection' has to be checked before to avoid interferences!
 		/// </summary>
 		public void ApplyConnection (ConnectionPort port, bool silent = false)
 		{
-			if (port == null)
+			if (port == null) 
 				return;
 
 			if (maxConnectionCount == ConnectionCount.Single && connections.Count > 0)
@@ -263,7 +263,6 @@ namespace NodeEditorFramework
 				port.body.OnRemoveConnection(this, port);
 				NodeEditorCallbacks.IssueOnRemoveConnection (this, port);
 			}
-
 			port.connections.Remove (this);
 			connections.Remove (port);
 
@@ -308,7 +307,7 @@ namespace NodeEditorFramework
 			Setup (name, direction, styleID, maxCount);
 		}
 
-		private void Setup (string name, Direction direction, string styleID, ConnectionCount maxCount)
+		private void Setup (string name, Direction direction, string styleID, ConnectionCount maxCount) 
 		{
 			Name = name;
 			Direction = direction;
@@ -316,7 +315,7 @@ namespace NodeEditorFramework
 			MaxConnectionCount = maxCount;
 		}
 
-		public bool MatchFieldType (Type fieldType)
+		public bool MatchFieldType (Type fieldType) 
 		{
 			return fieldType.IsAssignableFrom (ConnectionType);
 		}
@@ -334,7 +333,7 @@ namespace NodeEditorFramework
 			return true;
 		}
 
-		public virtual ConnectionPort CreateNew (Node body)
+		public virtual ConnectionPort CreateNew (Node body) 
 		{
 			ConnectionPort port = ScriptableObject.CreateInstance<ConnectionPort> ();
 			port.Init (body, Name);
@@ -344,7 +343,7 @@ namespace NodeEditorFramework
 			return port;
 		}
 
-		public virtual void UpdateProperties (ConnectionPort port)
+		public virtual void UpdateProperties (ConnectionPort port) 
 		{
 			port.name = Name;
 			port.direction = Direction;
@@ -364,7 +363,7 @@ namespace NodeEditorFramework
 
 		public ConnectionPortStyle () {}
 
-		public ConnectionPortStyle (string name)
+		public ConnectionPortStyle (string name) 
 		{
 			identifier = name;
 			GenerateColor();
@@ -375,7 +374,7 @@ namespace NodeEditorFramework
 			color = NodeEditorGUI.RandomColorHSV(Identifier.GetHashCode(), 0, 1, 0.6f, 0.8f, 0.8f, 1.4f);
 		}
 
-		public virtual bool isValid ()
+		public virtual bool isValid () 
 		{
 			return true;
 		}

--- a/Node_Editor_Framework/Runtime/Framework/Core/Node.cs
+++ b/Node_Editor_Framework/Runtime/Framework/Core/Node.cs
@@ -158,6 +158,11 @@ namespace NodeEditorFramework
 		/// Callback when the given port on this node was assigned a new connection
 		/// </summary>
 		protected internal virtual void OnAddConnection (ConnectionPort port, ConnectionPort connection) {}
+		
+		/// <summary>
+		/// Callback when the given port has a connection that was removed.
+		/// </summary>
+		protected internal virtual void OnRemoveConnection (ConnectionPort port, ConnectionPort connection) {}
 
 		/// <summary>
 		/// Should return all additional ScriptableObjects this Node references


### PR DESCRIPTION
Needed a way to override OnRemoveConnection from a class that inherits from Node like can be done with OnAddConnection. Small change but makes it so much nicer when I need to add functionality when a connection is removed.